### PR TITLE
fix set command machine cert var name

### DIFF
--- a/pre_logon_set/pre_logon_set.conf
+++ b/pre_logon_set/pre_logon_set.conf
@@ -4,7 +4,7 @@
 request certificate generate ca yes certificate-name {{ ca_cert_name }} name {{ ca_cert_name }} algorithm RSA rsa-nbits 2048
 # create GP certs signed by local root CA
 request certificate generate signed-by {{ ca_cert_name }} certificate-name {{ portal_cert_name }} name {{ portal_cert_fqdn }} algorithm RSA rsa-nbits 2048
-request certificate generate signed-by {{ ca_cert_name }} certificate-name {{ machine_cert_name }} name {{ machine_cert_fqdn }} algorithm RSA rsa-nbits 2048
+request certificate generate signed-by {{ ca_cert_name }} certificate-name {{ machine_cert_name }} name {{ machine_cert_name }} algorithm RSA rsa-nbits 2048
 
 configure
 set shared certificate-profile GP_Certificate_Profile CA {{ ca_cert_name }}


### PR DESCRIPTION
Correcting an incorrect var name for the machine cert in the pre-logon set commands. Now matches the var name in the yaml file.